### PR TITLE
Implement live quiz participant UI and state

### DIFF
--- a/client/src/components/live/JoinLive.tsx
+++ b/client/src/components/live/JoinLive.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const JoinLive: React.FC = () => {
+	const navigate = useNavigate();
+	const [pin, setPin] = useState('');
+	const [name, setName] = useState('');
+	const [email, setEmail] = useState('');
+	const [submitting, setSubmitting] = useState(false);
+
+	function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		setSubmitting(true);
+		const sessionId = pin || 'mock-session';
+		// Pass name/email via state; provider will connect in session route
+		navigate(`/live/session/${encodeURIComponent(sessionId)}`, { state: { name, email } });
+	}
+
+	return (
+		<div className='min-h-screen flex flex-col items-center justify-center px-4 bg-gray-50'>
+			<div className='w-full max-w-md bg-white rounded-xl shadow p-6'>
+				<h1 className='text-xl font-bold text-center mb-1'>Join Live Quiz</h1>
+				<p className='text-sm text-gray-500 text-center mb-6'>Enter the game PIN and your name</p>
+				<form onSubmit={handleSubmit} className='space-y-4'>
+					<div>
+						<label className='block text-sm font-medium text-gray-700 mb-1'>Game PIN</label>
+						<input
+							type='text'
+							inputMode='numeric'
+							pattern='[0-9]*'
+							placeholder='123456'
+							value={pin}
+							onChange={(e) => setPin(e.target.value)}
+							className='w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-emerald-500'
+							required
+						/>
+					</div>
+					<div>
+						<label className='block text-sm font-medium text-gray-700 mb-1'>Name</label>
+						<input
+							type='text'
+							placeholder='Your name'
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+							className='w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-emerald-500'
+							required
+						/>
+					</div>
+					<div>
+						<label className='block text-sm font-medium text-gray-700 mb-1'>Email (optional)</label>
+						<input
+							type='email'
+							placeholder='you@example.com'
+							value={email}
+							onChange={(e) => setEmail(e.target.value)}
+							className='w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-emerald-500'
+						/>
+					</div>
+					<button
+						type='submit'
+						disabled={!pin || !name || submitting}
+						className='w-full rounded-lg bg-emerald-600 text-white py-2.5 text-base font-semibold hover:bg-emerald-700 disabled:opacity-50'
+					>
+						Join
+					</button>
+				</form>
+				<p className='text-xs text-gray-400 text-center mt-4'>Powered by SigmaQ Live</p>
+			</div>
+		</div>
+	);
+};
+
+export default JoinLive;
+

--- a/client/src/components/live/LiveSession.tsx
+++ b/client/src/components/live/LiveSession.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { LiveQuizProvider, useLiveQuiz } from '../../contexts/LiveQuizContext';
+import { createMockLiveClient } from '../../utils/mockLiveClient';
+import RadialCountdown from './RadialCountdown';
+
+const ConnectionBadge: React.FC = () => {
+	const { connectionStatus } = useLiveQuiz();
+	const color = connectionStatus === 'connected' ? 'bg-emerald-500' : connectionStatus === 'retrying' ? 'bg-amber-500' : 'bg-gray-400';
+	const label = connectionStatus === 'connected' ? 'Connected' : connectionStatus === 'retrying' ? 'Retrying' : 'Disconnected';
+	return (
+		<span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium text-white ${color}`}>
+			<span className='inline-block h-1.5 w-1.5 rounded-full bg-white'></span>
+			{label}
+		</span>
+	);
+};
+
+const TopBar: React.FC = () => {
+	const { name, score } = useLiveQuiz();
+	return (
+		<div className='w-full flex items-center justify-between px-4 py-2 border-b border-gray-200'>
+			<div className='text-sm font-medium'>SigmaQ Live</div>
+			<div className='flex items-center gap-3'>
+				<div className='text-sm text-gray-600'>{name}</div>
+				<div className='text-sm font-semibold'>Score: {score}</div>
+				<ConnectionBadge />
+			</div>
+		</div>
+	);
+};
+
+const LobbyView: React.FC = () => {
+	return (
+		<div className='flex flex-1 items-center justify-center p-6'>
+			<div className='text-center'>
+				<h2 className='text-xl font-bold mb-2'>Waiting for the host to start…</h2>
+				<p className='text-gray-600'>Sit tight. The game will begin shortly.</p>
+			</div>
+		</div>
+	);
+};
+
+const QuestionView: React.FC = () => {
+	const { question, lastAnswer, selectAnswer, currentView, remainingMs, remainingPct } = useLiveQuiz();
+	if (!question) return null;
+	const locked = currentView === 'locked' || remainingMs <= 0;
+	return (
+		<div className='flex-1 p-4 flex flex-col gap-4'>
+			<div className='flex items-center justify-between'>
+				<h2 className='text-lg font-semibold'>{question.prompt}</h2>
+				<RadialCountdown remainingMs={remainingMs} remainingPct={remainingPct} />
+			</div>
+			<div className='grid grid-cols-1 sm:grid-cols-2 gap-3'>
+				{question.options.map((opt) => {
+					const selected = lastAnswer === opt.key;
+					return (
+						<button
+							key={opt.key}
+							onClick={() => selectAnswer(opt.key)}
+							disabled={locked}
+							className={`rounded-lg border px-4 py-3 text-left text-base font-medium transition ${
+								selected ? 'bg-emerald-50 border-emerald-300 text-emerald-800' : 'bg-white border-gray-300 hover:border-gray-400'
+							} ${locked ? 'opacity-60 cursor-not-allowed' : ''}`}
+						>
+							{opt.key}. {opt.label}
+						</button>
+					);
+				})}
+			</div>
+		</div>
+	);
+};
+
+const InnerSession: React.FC = () => {
+	const { state } = useLocation() as { state?: { name?: string; email?: string } };
+	const { sessionId } = useParams();
+	const navigate = useNavigate();
+	const { currentView, connectToSession } = useLiveQuiz();
+
+	useEffect(() => {
+		if (!sessionId) return;
+		const displayName = state?.name || 'Guest';
+		connectToSession(sessionId, displayName);
+	}, [sessionId]);
+
+	useEffect(() => {
+		if (!sessionId) navigate('/live/join');
+	}, [sessionId]);
+
+	return (
+		<div className='min-h-screen flex flex-col bg-gray-50'>
+			<TopBar />
+			{currentView === 'lobby' && <LobbyView />}
+			{(currentView === 'question' || currentView === 'locked') && <QuestionView />}
+		</div>
+	);
+};
+
+const LiveSession: React.FC = () => {
+	return (
+		<LiveQuizProvider clientFactory={createMockLiveClient}>
+			<InnerSession />
+		</LiveQuizProvider>
+	);
+};
+
+export default LiveSession;
+

--- a/client/src/components/live/RadialCountdown.tsx
+++ b/client/src/components/live/RadialCountdown.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+interface Props {
+	remainingMs: number;
+	remainingPct: number; // 0..1
+	totalSeconds?: number; // optional for display override
+}
+
+const SIZE = 80;
+const STROKE = 8;
+const RADIUS = (SIZE - STROKE) / 2;
+const CIRC = 2 * Math.PI * RADIUS;
+
+export const RadialCountdown: React.FC<Props> = ({ remainingMs, remainingPct }) => {
+	const seconds = Math.ceil(remainingMs / 1000);
+	const dashOffset = CIRC * (1 - remainingPct);
+	return (
+		<div className='flex flex-col items-center justify-center'>
+			<svg width={SIZE} height={SIZE} className='rotate-[-90deg]'>
+				<circle cx={SIZE / 2} cy={SIZE / 2} r={RADIUS} stroke='#e5e7eb' strokeWidth={STROKE} fill='none' />
+				<circle
+					cx={SIZE / 2}
+					cy={SIZE / 2}
+					r={RADIUS}
+					stroke='#10b981'
+					strokeWidth={STROKE}
+					fill='none'
+					strokeDasharray={`${CIRC} ${CIRC}`}
+					strokeDashoffset={dashOffset}
+					strokeLinecap='round'
+				/>
+			</svg>
+			<div className='-mt-14 text-center w-16 select-none'>
+				<div className='text-lg font-semibold'>{Math.max(0, seconds)}</div>
+				<div className='text-[10px] text-gray-500'>sec</div>
+			</div>
+		</div>
+	);
+};
+
+export default RadialCountdown;
+

--- a/client/src/contexts/LiveQuizContext.tsx
+++ b/client/src/contexts/LiveQuizContext.tsx
@@ -1,0 +1,248 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useReducer, useRef } from 'react';
+
+export type LiveView = 'lobby' | 'question' | 'locked' | 'feedback' | 'leaderboard' | 'end';
+
+export interface LiveQuestionOption {
+	key: string;
+	label: string;
+}
+
+export interface LiveQuestion {
+	id: string;
+	prompt: string;
+	options: LiveQuestionOption[];
+}
+
+export interface LiveQuizState {
+	sessionId: string | null;
+	userId: string | null;
+	name: string | null;
+	connected: boolean;
+	connectionStatus: 'connected' | 'retrying' | 'disconnected';
+	currentView: LiveView;
+	question: LiveQuestion | null;
+	endsAt: number | null; // server epoch ms
+	serverNow: number | null; // server epoch ms at last sync
+	lastAnswer: string | null;
+	score: number;
+}
+
+export type LiveEventType =
+	| 'session_started'
+	| 'question'
+	| 'question_lock'
+	| 'question_result'
+	| 'leaderboard'
+	| 'session_end';
+
+export interface LiveEventPayloads {
+	question: { question: LiveQuestion; endsAt: number; serverNow: number };
+	question_lock: { serverNow: number };
+	question_result: { correctOptionKey: string; scoreDelta: number };
+	leaderboard: { top: Array<{ name: string; score: number }>; score: number };
+	session_end: {};
+	session_started: {};
+}
+
+export interface LiveClientLike {
+	connect: (sessionId: string, userId: string, name: string) => void;
+	disconnect: () => void;
+	on: <K extends LiveEventType>(event: K, handler: (payload: LiveEventPayloads[K]) => void) => void;
+	off: <K extends LiveEventType>(event: K, handler: (payload: LiveEventPayloads[K]) => void) => void;
+	sendAnswer?: (optionKey: string) => void;
+}
+
+export interface LiveQuizContextValue extends LiveQuizState {
+	connectToSession: (sessionId: string, name: string) => void;
+	disconnect: () => void;
+	selectAnswer: (optionKey: string) => void;
+	remainingMs: number;
+	remainingPct: number; // 0..1
+}
+
+const initialState: LiveQuizState = {
+	sessionId: null,
+	userId: null,
+	name: null,
+	connected: false,
+	connectionStatus: 'disconnected',
+	currentView: 'lobby',
+	question: null,
+	endsAt: null,
+	serverNow: null,
+	lastAnswer: null,
+	score: 0,
+};
+
+type Action =
+	| { type: 'SET_CONNECTION'; connected: boolean; status: LiveQuizState['connectionStatus'] }
+	| { type: 'JOINED'; sessionId: string; userId: string; name: string }
+	| { type: 'SET_VIEW'; view: LiveView }
+	| { type: 'QUESTION'; question: LiveQuestion; endsAt: number; serverNow: number }
+	| { type: 'LOCK'; serverNow: number }
+	| { type: 'ANSWER'; optionKey: string }
+	| { type: 'RESULT'; scoreDelta: number }
+	| { type: 'END' };
+
+function reducer(state: LiveQuizState, action: Action): LiveQuizState {
+	switch (action.type) {
+		case 'SET_CONNECTION':
+			return { ...state, connected: action.connected, connectionStatus: action.status };
+		case 'JOINED':
+			return {
+				...state,
+				sessionId: action.sessionId,
+				userId: action.userId,
+				name: action.name,
+				currentView: 'lobby',
+				lastAnswer: null,
+				score: 0,
+			};
+		case 'SET_VIEW':
+			return { ...state, currentView: action.view };
+		case 'QUESTION':
+			return {
+				...state,
+				currentView: 'question',
+				question: action.question,
+				endsAt: action.endsAt,
+				serverNow: action.serverNow,
+				lastAnswer: null,
+			};
+		case 'LOCK':
+			return { ...state, currentView: 'locked', serverNow: action.serverNow };
+		case 'ANSWER':
+			return { ...state, lastAnswer: action.optionKey };
+		case 'RESULT':
+			return { ...state, currentView: 'feedback', score: state.score + action.scoreDelta };
+		case 'END':
+			return { ...state, currentView: 'end' };
+		default:
+			return state;
+	}
+}
+
+const LiveQuizContext = createContext<LiveQuizContextValue | undefined>(undefined);
+
+function generateUserId(): string {
+	return 'u_' + Math.random().toString(36).slice(2, 10);
+}
+
+export const LiveQuizProvider: React.FC<{ children: React.ReactNode; clientFactory: () => LiveClientLike }> = ({ children, clientFactory }) => {
+	const [state, dispatch] = useReducer(reducer, initialState);
+	const clientRef = useRef<LiveClientLike | null>(null);
+	const questionStartLocalTimeRef = useRef<number | null>(null);
+	const lastServerNowAtQuestionRef = useRef<number | null>(null);
+    const rafRef = useRef<number | null>(null);
+
+	const connectToSession = useCallback(
+		(sessionId: string, name: string) => {
+			const userId = generateUserId();
+			dispatch({ type: 'JOINED', sessionId, userId, name });
+			if (!clientRef.current) {
+				clientRef.current = clientFactory();
+			}
+			const client = clientRef.current;
+			client.connect(sessionId, userId, name);
+			dispatch({ type: 'SET_CONNECTION', connected: true, status: 'connected' });
+
+			const handleSessionStarted = () => {
+				dispatch({ type: 'SET_VIEW', view: 'lobby' });
+			};
+			const handleQuestion = (payload: LiveEventPayloads['question']) => {
+				questionStartLocalTimeRef.current = performance.now();
+				lastServerNowAtQuestionRef.current = payload.serverNow;
+				dispatch({ type: 'QUESTION', question: payload.question, endsAt: payload.endsAt, serverNow: payload.serverNow });
+			};
+			const handleLock = (payload: LiveEventPayloads['question_lock']) => {
+				dispatch({ type: 'LOCK', serverNow: payload.serverNow });
+			};
+			const handleResult = (payload: LiveEventPayloads['question_result']) => {
+				dispatch({ type: 'RESULT', scoreDelta: payload.scoreDelta });
+			};
+			const handleEnd = () => {
+				dispatch({ type: 'END' });
+			};
+
+			client.on('session_started', handleSessionStarted);
+			client.on('question', handleQuestion);
+			client.on('question_lock', handleLock);
+			client.on('question_result', handleResult);
+			client.on('session_end', handleEnd);
+		},
+		[clientFactory]
+	);
+
+	const disconnect = useCallback(() => {
+		if (clientRef.current) {
+			clientRef.current.disconnect();
+		}
+		dispatch({ type: 'SET_CONNECTION', connected: false, status: 'disconnected' });
+	}, []);
+
+	const selectAnswer = useCallback((optionKey: string) => {
+		dispatch({ type: 'ANSWER', optionKey });
+		if (clientRef.current?.sendAnswer) {
+			clientRef.current.sendAnswer(optionKey);
+		}
+	}, []);
+
+	// Time sync: compute remaining based on serverNow and local high-res elapsed
+
+	// Drive countdown with a RAF tick stored in refs and mirrored via state changes that re-render parent consumers
+	const [tick, setTick] = React.useState(0);
+	useEffect(() => {
+		function loop() {
+			setTick((t) => (t + 1) % 1000000);
+			rafRef.current = requestAnimationFrame(loop);
+		}
+		// Only animate when in question/locked
+		if (state.currentView === 'question' || state.currentView === 'locked') {
+			rafRef.current = requestAnimationFrame(loop);
+			return () => {
+				if (rafRef.current) cancelAnimationFrame(rafRef.current);
+				rafRef.current = null;
+			};
+		}
+		return () => {};
+	}, [state.currentView]);
+
+	const { remainingMs, remainingPct } = useMemo(() => {
+		const endsAt = state.endsAt;
+		const serverNowAtQuestion = lastServerNowAtQuestionRef.current;
+		const questionStartLocal = questionStartLocalTimeRef.current;
+		if (!endsAt || !serverNowAtQuestion || !questionStartLocal) {
+			return { remainingMs: 0, remainingPct: 0 };
+		}
+		const now = serverNowAtQuestion + (performance.now() - questionStartLocal);
+		const remaining = Math.max(0, endsAt - now);
+		const total = endsAt - serverNowAtQuestion;
+		const pct = total > 0 ? Math.max(0, Math.min(1, remaining / total)) : 0;
+		return { remainingMs: remaining, remainingPct: pct };
+	}, [state.endsAt, state.serverNow, state.currentView, tick]);
+
+	// Local lock when countdown hits 0 and server has not locked yet
+	useEffect(() => {
+		if (state.currentView === 'question' && remainingMs <= 0) {
+			dispatch({ type: 'SET_VIEW', view: 'locked' });
+		}
+	}, [state.currentView, remainingMs]);
+
+	const value: LiveQuizContextValue = {
+		...state,
+		connectToSession,
+		disconnect,
+		selectAnswer,
+		remainingMs,
+		remainingPct,
+	};
+
+	return <LiveQuizContext.Provider value={value}>{children}</LiveQuizContext.Provider>;
+};
+
+export function useLiveQuiz(): LiveQuizContextValue {
+	const ctx = useContext(LiveQuizContext);
+	if (!ctx) throw new Error('useLiveQuiz must be used within LiveQuizProvider');
+	return ctx;
+}
+

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -16,6 +16,8 @@ import TermsPage from './components/landing/TermsPage';
 import CaseStudiesPage from './components/landing/CaseStudiesPage';
 import PricingPage from './components/landing/PricingPage';
 import ResponsiveLayoutDemo from './components/survey/ResponsiveLayoutDemo';
+import JoinLive from './components/live/JoinLive';
+import LiveSession from './components/live/LiveSession';
 import './styles.css';
 import './styles/markdown.css';
 import './i18n';
@@ -78,6 +80,9 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 					<Route path='/:companySlug/survey/:slug' element={<TakeSurvey />} />
 					<Route path='/:companySlug/assessment/:slug' element={<TakeAssessment />} />
 					<Route path='/legacy' element={<Survey />} />
+					{/* Live quiz participant routes */}
+					<Route path='/live/join' element={<JoinLive />} />
+					<Route path='/live/session/:sessionId' element={<LiveSession />} />
 				</Routes>
 			</AnalyticsProvider>
 		</BrowserRouter>

--- a/client/src/utils/mockLiveClient.ts
+++ b/client/src/utils/mockLiveClient.ts
@@ -1,0 +1,63 @@
+import type { LiveClientLike, LiveEventPayloads, LiveEventType, LiveQuestion } from '../contexts/LiveQuizContext';
+
+type HandlerMap = {
+	[K in LiveEventType]?: Array<(payload: any) => void>;
+};
+
+export function createMockLiveClient(): LiveClientLike {
+	let handlers: HandlerMap = {};
+	let intervalId: number | null = null;
+
+	function emit<K extends LiveEventType>(event: K, payload: LiveEventPayloads[K]) {
+		handlers[event]?.forEach((h) => h(payload));
+	}
+
+	function connect(sessionId: string, userId: string, name: string) {
+		// Simulate server lifecycle: lobby -> question -> lock -> result
+		window.setTimeout(() => emit('session_started', {}), 300);
+
+		// After a short lobby, send a question with a 10s timer
+		window.setTimeout(() => {
+			const serverNow = Date.now();
+			const endsAt = serverNow + 10000;
+			const question: LiveQuestion = {
+				id: 'q1',
+				prompt: 'What is 2 + 2?',
+				options: [
+					{ key: 'A', label: '3' },
+					{ key: 'B', label: '4' },
+					{ key: 'C', label: '5' },
+					{ key: 'D', label: '22' },
+				],
+			};
+			emit('question', { question, endsAt, serverNow });
+
+			// Lock slightly after endsAt to test local lock behavior
+			window.setTimeout(() => {
+				emit('question_lock', { serverNow: Date.now() });
+				window.setTimeout(() => {
+					emit('question_result', { correctOptionKey: 'B', scoreDelta: 1000 });
+				}, 800);
+			}, 11000);
+		}, 1000);
+	}
+
+	function disconnect() {
+		if (intervalId) {
+			window.clearInterval(intervalId);
+			intervalId = null;
+		}
+	}
+
+	function on<K extends LiveEventType>(event: K, handler: (payload: LiveEventPayloads[K]) => void) {
+		if (!handlers[event]) handlers[event] = [];
+		handlers[event]!.push(handler as any);
+	}
+
+	function off<K extends LiveEventType>(event: K, handler: (payload: LiveEventPayloads[K]) => void) {
+		handlers[event] = (handlers[event] || []).filter((h) => h !== handler);
+	}
+
+	return { connect, disconnect, on, off };
+}
+


### PR DESCRIPTION
Add Kahoot-style Live Quiz participant UI to implement a tester UI for Live Quizzes.

---
<a href="https://cursor.com/background-agent?bcId=bc-93bf153a-e5f3-48a1-a492-84988ac7e3d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-93bf153a-e5f3-48a1-a492-84988ac7e3d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

