### PR TITLE
Fix assessment url slug database storage

### DIFF
--- a/client/src/TakeAssessment.tsx
+++ b/client/src/TakeAssessment.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import axios from 'axios';
 import { useAntiCheating } from './hooks/useAntiCheating';
 import { useSimpleAntiCheating } from './hooks/useSimpleAntiCheating';
@@ -39,6 +39,8 @@ type StepType = 'instructions' | 'questions' | 'results';
 const TakeAssessment: React.FC = () => {
 	const { slug, companySlug } = useParams<{ slug: string; companySlug?: string }>();
 	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+	const invitationCode = searchParams.get('invitation');
 
 	// Helper function to generate API paths with multi-tenant support
 	const getApiPath = (path: string) => {
@@ -219,6 +221,7 @@ const TakeAssessment: React.FC = () => {
 			const startResp = await axios.post(getApiPath(`/assessment/${slug}/start`), {
 				name: form.name,
 				email: form.email,
+				...(invitationCode && { invitationCode }),
 			});
 			setQuestions(startResp.data.questions || []);
 			setQuestionsLoaded(true);
@@ -395,6 +398,7 @@ const TakeAssessment: React.FC = () => {
 				answerDurations: Object.fromEntries(
 					Object.entries(finalQuestionTimings).map(([idx, v]) => [idx, v.duration || 0])
 				),
+				...(invitationCode && { invitationCode }),
 			};
 
 			console.log('Submitting to API', {

--- a/client/src/components/modals/InviteAssessmentModal.tsx
+++ b/client/src/components/modals/InviteAssessmentModal.tsx
@@ -7,6 +7,7 @@ interface InviteAssessmentModalProps {
 	onClose: () => void;
 	surveyId: string;
 	surveyTitle: string;
+	surveySlug: string;
 }
 
 const PAGE_SIZE = 10;
@@ -16,6 +17,7 @@ const InviteAssessmentModal: React.FC<InviteAssessmentModalProps> = ({
 	onClose,
 	surveyId,
 	surveyTitle,
+	surveySlug,
 }) => {
 	const [emails, setEmails] = useState('');
 	const [expiresInDays, setExpiresInDays] = useState(7);
@@ -114,7 +116,7 @@ const InviteAssessmentModal: React.FC<InviteAssessmentModalProps> = ({
 	// 复制链接
 	const handleCopy = (token: string) => {
 		const basePath = companySlug ? `/${companySlug}` : '';
-		const url = `${window.location.origin}${basePath}/assessment/${token}`;
+		const url = `${window.location.origin}${basePath}/assessment/${surveySlug}?invitation=${token}`;
 		navigator.clipboard.writeText(url);
 	};
 

--- a/client/src/components/surveys/SurveyDetailView.tsx
+++ b/client/src/components/surveys/SurveyDetailView.tsx
@@ -474,7 +474,7 @@ const SurveyDetailView: React.FC<SurveyDetailViewProps> = ({ survey }) => {
 					/>
 				)}
 				{tabLocal === TAB_TYPES.INVITATIONS && (
-					<SurveyInvitationsTab surveyId={survey._id} companySlug={companySlug} />
+					<SurveyInvitationsTab surveyId={survey._id} surveySlug={survey.slug} companySlug={companySlug} />
 				)}
 				{/* Preview tab removed in favor of inline toggle in Assessment Details */}
 				{/* Only show modal when showInviteModal is true */}
@@ -484,6 +484,7 @@ const SurveyDetailView: React.FC<SurveyDetailViewProps> = ({ survey }) => {
 						onClose={() => setShowInviteModal(false)}
 						surveyId={survey._id}
 						surveyTitle={survey.title}
+						surveySlug={survey.slug}
 					/>
 				)}
 

--- a/client/src/components/surveys/tabs/SurveyInvitationsTab.tsx
+++ b/client/src/components/surveys/tabs/SurveyInvitationsTab.tsx
@@ -3,12 +3,13 @@ import api from '../../../utils/axiosConfig';
 
 interface Props {
 	surveyId: string;
+	surveySlug: string;
 	companySlug: string;
 }
 
 const PAGE_SIZE = 10;
 
-const SurveyInvitationsTab: React.FC<Props> = ({ surveyId, companySlug }) => {
+const SurveyInvitationsTab: React.FC<Props> = ({ surveyId, surveySlug, companySlug }) => {
 	const [invitations, setInvitations] = useState<any[]>([]);
 	const [loading, setLoading] = useState(false);
 	const [page, setPage] = useState(1);
@@ -53,7 +54,7 @@ const SurveyInvitationsTab: React.FC<Props> = ({ surveyId, companySlug }) => {
 
 	const handleCopy = (token: string) => {
 		const basePath = companySlug ? `/${companySlug}` : '';
-		const url = `${window.location.origin}${basePath}/assessment/${token}`;
+		const url = `${window.location.origin}${basePath}/assessment/${surveySlug}?invitation=${token}`;
 		navigator.clipboard.writeText(url);
 	};
 

--- a/models/Survey.js
+++ b/models/Survey.js
@@ -336,6 +336,15 @@ const surveySchema = new mongoose.Schema({
 	},
 });
 
+// Pre-save middleware to generate slug if not provided
+surveySchema.pre('save', async function (next) {
+	// Only generate slug if it's not already set and we have a title
+	if (!this.slug && this.title) {
+		this.slug = await this.constructor.generateSlug(this.title, this._id);
+	}
+	next();
+});
+
 // Helper function to generate unique slug
 surveySchema.statics.generateSlug = async function (title, excludeId = null) {
 	let baseSlug = title

--- a/routes/invitations.js
+++ b/routes/invitations.js
@@ -84,8 +84,8 @@ router.post(
 						createdBy,
 					});
 
-					// 生成 assessment 专属链接
-					const link = `${process.env.BASE_URL || 'http://localhost:5173'}/assessment/${invitation.invitationCode}`;
+					// 生成 assessment 专属链接 - 使用 survey slug 而不是 invitation code
+					const link = `${process.env.BASE_URL || 'http://localhost:5173'}/assessment/${survey.slug}?invitation=${invitation.invitationCode}`;
 					const expireText = expiresAt
 						? `此链接将在 ${new Date(expiresAt).toLocaleDateString()} 过期。`
 						: '';


### PR DESCRIPTION
Fix assessment access by using database-stored survey slugs in URLs and properly handling invitation codes for validation.

The production issue arose because assessment URLs were being generated on the frontend using invitation codes as the main identifier, but the backend expected a survey slug. This PR ensures that survey slugs are consistently used for routing, and invitation codes are correctly passed as query parameters for access control, resolving the "assessment not found" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-7454d4c0-b2fb-498f-a9f1-e96530d210bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7454d4c0-b2fb-498f-a9f1-e96530d210bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

